### PR TITLE
Fix to https://issues.openmrs.org/browse/ERR-652

### DIFF
--- a/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/drawing/elements/DrawingSubmissionElement.java
@@ -25,6 +25,9 @@ import org.openmrs.module.htmlformentry.element.HtmlGeneratorElement;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.web.WebConstants;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 //public class DrawingSubmissionElement {
 	public class DrawingSubmissionElement implements HtmlGeneratorElement, FormSubmissionControllerAction {
 	
@@ -71,12 +74,14 @@ import org.openmrs.web.WebConstants;
 		try {
 			AnnotatedImage ai = new AnnotatedImage(DrawingUtil.base64ToImage(encodedImage));
 			ai.setAnnotations(DrawingUtil.getAnnotations(submission, id));
-			if (session.getContext().getMode() == Mode.EDIT && existingObs != null)
+			if (session.getContext().getMode() == Mode.EDIT && existingObs != null){
 				session.getSubmissionActions().modifyObs(existingObs, questionConcept,
 				    new ComplexData(existingObs.getComplexData().getTitle(), ai), null, null);
-			else
-				session.getSubmissionActions().createObs(questionConcept, new ComplexData("drawingObs.png", ai), null, null);
-			
+			}else{
+				String filename = "drawingObs" + new SimpleDateFormat("yyyyMMddhhmmssSSSSSSS").format(new Date()) + ".png";
+				session.getSubmissionActions().createObs(questionConcept, new ComplexData(filename, ai), null, null);
+				//session.getSubmissionActions().createObs(questionConcept, new ComplexData("drawingObs.png", ai), null, null);
+			}
 		}
 		catch (Exception e) {
 			log.error("cannot create obs :" + e.getMessage(), e);

--- a/omod/src/main/java/org/openmrs/module/drawing/web/controller/DrawingWindowController.java
+++ b/omod/src/main/java/org/openmrs/module/drawing/web/controller/DrawingWindowController.java
@@ -27,6 +27,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 @Controller
 public class DrawingWindowController {
 	
@@ -50,7 +53,10 @@ public class DrawingWindowController {
 			o.setEncounter(encounter);
 			AnnotatedImage ai = new AnnotatedImage(DrawingUtil.base64ToImage(encodedImage));
 			ai.setAnnotations(DrawingUtil.getAnnotations(request, ""));
-			o.setComplexData(new ComplexData("drawingObs.png", ai));
+			String filename = "drawingObs" + new SimpleDateFormat("yyyyMMddhhmmssSSSSSSS").format(new Date()) + ".png";
+			o.setComplexData(new ComplexData(filename, ai));
+//			o.setComplexData(new ComplexData("drawingObs.png", ai));
+
 			Errors obsErrors = new BindException(o, "obs");
 			ValidationUtils.invokeValidator(new ObsValidator(), o, obsErrors);
 			if (!obsErrors.hasErrors()) {


### PR DESCRIPTION
Hi @ravipatipushkar,

This is a fix to https://issues.openmrs.org/browse/ERR-652.

Basically, what this updated code does is, it saves the uploaded image 
in "drawingObs[timestamp].png" instead of just "drawingObs.png".

This is because, in OpenMRS, if you upload a file 
and the file has a similar filename in the server already, 
the file will be stored in "drawingObs_[counter].png".
However, [counter] loops up to 100 only 
(See getOutputFileToWrite method in Abstracthandler Class).
So if the counter is 100 already, any uploaded drawing image 
will just overwrite the drawingObs_100.png.

I hope you consider this revision and merge it with the next release of drawing module.
## Thanks!

Cereblanco@gmail.com
